### PR TITLE
Improve syntax highlighting of Swift code.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+target
+*.wasm
+grammars
+*.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # zed-swift-extension
- Extension for Zed to support [Swift](https://github.com/samuser107/zed-swift-extension)
+
+Swift syntax highlighting & language server for [Zed](https://github.com/zed-industries/zed)

--- a/extension.json
+++ b/extension.json
@@ -1,9 +1,0 @@
-{
-  "name": "Swift",
-  "version": "0.1.0",
-  "authors": [
-    "Samuser107 L.Longheval <samuser107@gmail.com>"
-  ],
-  "description": "Provides Swift syntax highlightingin Zed",
-  "repository": "https://github.com/samuser107/zed-swift-extension"
-}

--- a/extension.toml
+++ b/extension.toml
@@ -1,0 +1,15 @@
+id = "swift"
+name = "Swift"
+description = "Swift LSP & syntax highlighting!"
+version = "0.0.1"
+schema_version = 1
+authors = ["ejjonny <https://github.com/ejjonny>"]
+repository = "https://github.com/zed-extensions/swift/"
+
+[grammars.swift]
+repository = "https://github.com/alex-pinkus/tree-sitter-swift"
+commit = "caa99d7d3c14aac03b5f16fc86fedf8755570760" #0.4.3
+
+[language_servers.sourcekit-lsp]
+name = "sourcekit-lsp"
+language = "Swift"

--- a/extension.toml
+++ b/extension.toml
@@ -1,9 +1,9 @@
 id = "swift"
 name = "Swift"
-description = "Swift LSP & syntax highlighting!"
-version = "0.0.1"
+description = "Swift LSP & syntax highlighting."
+version = "0.2.0"
 schema_version = 1
-authors = ["ejjonny <https://github.com/ejjonny>"]
+authors = ["ejjonny <https://github.com/ejjonny>", "Samuser107"]
 repository = "https://github.com/zed-extensions/swift/"
 
 [grammars.swift]

--- a/grammars/swift.toml
+++ b/grammars/swift.toml
@@ -1,2 +1,0 @@
-repository = "https://github.com/alex-pinkus/tree-sitter-swift.git"
-commit = "b1b66955d420d5cf5ff268ae552f0d6e43ff66e1"

--- a/languages/swift/config.toml
+++ b/languages/swift/config.toml
@@ -2,11 +2,12 @@ name = "Swift"
 grammar = "swift"
 path_suffixes = ["swift"]
 line_comments = ["//"]
-autoclose_before = "}])"
+block_comment = ["/*", "*/"]
+autoclose_before = ")}]"
 brackets = [
-  { start = "{", end = "}", close = true, newline = true },
-  { start = "(", end = ")", close = true, newline = true },
-  { start = "[", end = "]", close = true, newline = true },
-  { start = "\"", end = "\"", close = true, newline = false },
-  { start = "'", end = "'", close = true, newline = false },
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
+    { start = "\"", end = "\"", close = true, newline = false },
+    { start = "'", end = "'", close = true, newline = false },
 ]

--- a/languages/swift/highlights.scm
+++ b/languages/swift/highlights.scm
@@ -19,7 +19,7 @@
   (mutation_modifier)
 ] @keyword
 
-(function_declaration (simple_identifier) @method)
+(function_declaration (simple_identifier) @function.method)
 (init_declaration ["init" @constructor])
 (deinit_declaration ["deinit" @constructor])
 (throws) @keyword
@@ -71,7 +71,8 @@
 (class_body (property_declaration (pattern (simple_identifier) @property)))
 (protocol_property_declaration (pattern (simple_identifier) @property))
 
-(value_argument name: (value_argument_label) @variable.member)
+(value_argument
+  name: (value_argument_label) @variable.member)
 
 (import_declaration
   "import" @keyword.import)
@@ -96,25 +97,38 @@
 (diagnostic) @function.macro
 
 ; Statements
-(for_statement ["for" @repeat])
-(for_statement ["in" @repeat])
+(for_statement ["for" @keyword.repeat])
+(for_statement ["in" @keyword.repeat])
 (for_statement (pattern) @variable)
 (else) @keyword
 (as_operator) @keyword
 
-["while" "repeat" "continue" "break"] @repeat
+["while" "repeat" "continue" "break"] @keyword.repeat
 
 ["let" "var"] @keyword
 
-(guard_statement ["guard" @conditional])
-(if_statement ["if" @conditional])
-(switch_statement ["switch" @conditional])
-(switch_entry ["case" @keyword])
-(switch_entry ["fallthrough" @keyword])
-(switch_entry (default_keyword) @keyword)
+(guard_statement
+  "guard" @keyword.conditional)
+  
+(if_statement
+  "if" @keyword.conditional)
+
+(switch_statement
+  "switch" @keyword.conditional)
+
+(switch_entry
+  "case" @keyword)
+
+(switch_entry
+  "fallthrough" @keyword)
+
+(switch_entry
+  (default_keyword) @keyword)
+
 "return" @keyword.return
+
 (ternary_expression
-  ["?" ":"] @conditional)
+  ["?" ":"] @keyword.conditional)
 
 ["do" (throw_keyword) (catch_keyword)] @keyword
 
@@ -154,9 +168,9 @@
   (oct_literal)
   (bin_literal)
 ] @number
-(real_literal) @float
+(real_literal) @number.float
 (boolean_literal) @boolean
-"nil" @constant.builtin
+"nil" @variable.builtin
 
 ; Regex literals
 (regex_literal) @string.regexp

--- a/languages/swift/highlights.scm
+++ b/languages/swift/highlights.scm
@@ -26,11 +26,11 @@
 "async" @keyword
 "await" @keyword
 (where_keyword) @keyword
-(parameter external_name: (simple_identifier) @parameter)
-(parameter name: (simple_identifier) @parameter)
-(type_parameter (type_identifier) @parameter)
-(inheritance_constraint (identifier (simple_identifier) @parameter))
-(equality_constraint (identifier (simple_identifier) @parameter))
+(parameter external_name: (simple_identifier) @property)
+(parameter name: (simple_identifier) @property)
+(type_parameter (type_identifier) @property)
+(inheritance_constraint (identifier (simple_identifier) @property))
+(equality_constraint (identifier (simple_identifier) @property))
 (pattern bound_identifier: (simple_identifier)) @variable
 
 [
@@ -68,11 +68,11 @@
   (modify_specifier)
 ] @keyword
 
-(class_body (property_declaration (pattern (simple_identifier) @property)))
-(protocol_property_declaration (pattern (simple_identifier) @property))
+(class_body (property_declaration (pattern (simple_identifier) @variable.parameter)))
+(protocol_property_declaration (pattern (simple_identifier) @variable.parameter))
 
 (value_argument
-  name: (value_argument_label) @variable.member)
+  name: (value_argument_label) @property)
 
 (import_declaration
   "import" @keyword.import)
@@ -87,7 +87,7 @@
     (navigation_suffix (simple_identifier) @function.call)))
 ((navigation_expression
    (simple_identifier) @type) ; SomeType.method(): highlight SomeType as a type
-   (#match? @type "^[A-Z]"))
+   (#match? @property "^[A-Z]"))
 (call_expression (simple_identifier) @keyword (#eq? @keyword "defer")) ; defer { ... }
 
 (try_operator) @operator
@@ -170,7 +170,7 @@
 ] @number
 (real_literal) @number.float
 (boolean_literal) @boolean
-"nil" @variable.builtin
+"nil" @keyword
 
 ; Regex literals
 (regex_literal) @string.regexp

--- a/languages/swift/highlights.scm
+++ b/languages/swift/highlights.scm
@@ -1,31 +1,14 @@
-[
-  "."
-  ";"
-  ":"
-  ","
-] @punctuation.delimiter
-
-; TODO: "\\(" ")" in interpolations should be @punctuation.special
-[
-  "\\("
-  "("
-  ")"
-  "["
-  "]"
-  "{"
-  "}"
-] @punctuation.bracket
+[ "." ";" ":" "," ] @punctuation.delimiter
+[ "\\(" "(" ")" "[" "]" "{" "}" ] @punctuation.bracket ; TODO: "\\(" ")" in interpolations should be @punctuation.special
 
 ; Identifiers
 (attribute) @variable
-
 (type_identifier) @type
-
 (self_expression) @variable.builtin
+(user_type (type_identifier) @variable.builtin (#eq? @variable.builtin "Self"))
 
 ; Declarations
 "func" @keyword.function
-
 [
   (visibility_modifier)
   (member_modifier)
@@ -34,37 +17,23 @@
   (parameter_modifier)
   (inheritance_modifier)
   (mutation_modifier)
-] @type.qualifier
+] @keyword
 
-(function_declaration
-  (simple_identifier) @function.method)
+(function_declaration (simple_identifier) @method)
 
-(function_declaration
-  "init" @constructor)
-
+(function_declaration (simple_identifier) @method)
+(init_declaration ["init" @constructor])
+(deinit_declaration ["deinit" @constructor])
 (throws) @keyword
-
+"async" @keyword
+"await" @keyword
 (where_keyword) @keyword
-
-(parameter
-  external_name: (simple_identifier) @variable.parameter)
-
-(parameter
-  name: (simple_identifier) @variable.parameter)
-
-(type_parameter
-  (type_identifier) @variable.parameter)
-
-(inheritance_constraint
-  (identifier
-    (simple_identifier) @variable.parameter))
-
-(equality_constraint
-  (identifier
-    (simple_identifier) @variable.parameter))
-
-(pattern
-  bound_identifier: (simple_identifier)) @variable
+(parameter external_name: (simple_identifier) @parameter)
+(parameter name: (simple_identifier) @parameter)
+(type_parameter (type_identifier) @parameter)
+(inheritance_constraint (identifier (simple_identifier) @parameter))
+(equality_constraint (identifier (simple_identifier) @parameter))
+(pattern bound_identifier: (simple_identifier)) @variable
 
 [
   "typealias"
@@ -79,13 +48,21 @@
   "override"
   "convenience"
   "required"
-  "some"
+  "mutating"
+  "nonmutating"
+  "associatedtype"
 ] @keyword
 
-[
-  "async"
-  "await"
-] @keyword.coroutine
+(opaque_type ["some" @keyword])
+(existential_type ["any" @keyword])
+
+(precedence_group_declaration
+ ["precedencegroup" @keyword]
+ (simple_identifier) @type)
+(precedence_group_attribute
+ (simple_identifier) @keyword
+ [(simple_identifier) @type
+  (boolean_literal) @boolean])
 
 [
   (getter_specifier)
@@ -93,21 +70,10 @@
   (modify_specifier)
 ] @keyword
 
-(class_body
-  (property_declaration
-    (pattern
-      (simple_identifier) @variable.member)))
+(class_body (property_declaration (pattern (simple_identifier) @property)))
+(protocol_property_declaration (pattern (simple_identifier) @property))
 
-(protocol_property_declaration
-  (pattern
-    (simple_identifier) @variable.member))
-
-(navigation_expression
-  (navigation_suffix
-    (simple_identifier) @variable.member))
-
-(value_argument
-  name: (value_argument_label) @variable.member)
+(value_argument name: (value_argument_label) @variable.member)
 
 (import_declaration
   "import" @keyword.import)
@@ -116,84 +82,43 @@
   "case" @keyword)
 
 ; Function calls
-(call_expression
-  (simple_identifier) @function.call) ; foo()
-
-(call_expression
-  ; foo.bar.baz(): highlight the baz()
+(call_expression (simple_identifier) @function.call) ; foo()
+(call_expression ; foo.bar.baz(): highlight the baz()
   (navigation_expression
-    (navigation_suffix
-      (simple_identifier) @function.call)))
-
-(call_expression
-  (prefix_expression
-    (simple_identifier) @function.call)) ; .foo()
-
+    (navigation_suffix (simple_identifier) @function.call)))
 ((navigation_expression
-  (simple_identifier) @type) ; SomeType.method(): highlight SomeType as a type
-  (#lua-match? @type "^[A-Z]"))
+   (simple_identifier) @type) ; SomeType.method(): highlight SomeType as a type
+   (#match? @type "^[A-Z]"))
+(call_expression (simple_identifier) @keyword (#eq? @keyword "defer")) ; defer { ... }
+
+(try_operator) @operator
+(try_operator ["try" @keyword])
 
 (directive) @function.macro
-
 (diagnostic) @function.macro
 
 ; Statements
-(for_statement
-  "for" @keyword.repeat)
-
-(for_statement
-  "in" @keyword.repeat)
-
-(for_statement
-  (pattern) @variable)
-
+(for_statement ["for" @repeat])
+(for_statement ["in" @repeat])
+(for_statement (pattern) @variable)
 (else) @keyword
-
 (as_operator) @keyword
 
-[
-  "while"
-  "repeat"
-  "continue"
-  "break"
-] @keyword.repeat
+["while" "repeat" "continue" "break"] @repeat
 
-[
-  "let"
-  "var"
-] @keyword
+["let" "var"] @keyword
 
-(guard_statement
-  "guard" @keyword.conditional)
-
-(if_statement
-  "if" @keyword.conditional)
-
-(switch_statement
-  "switch" @keyword.conditional)
-
-(switch_entry
-  "case" @keyword)
-
-(switch_entry
-  "fallthrough" @keyword)
-
-(switch_entry
-  (default_keyword) @keyword)
-
+(guard_statement ["guard" @conditional])
+(if_statement ["if" @conditional])
+(switch_statement ["switch" @conditional])
+(switch_entry ["case" @keyword])
+(switch_entry ["fallthrough" @keyword])
+(switch_entry (default_keyword) @keyword)
 "return" @keyword.return
-
 (ternary_expression
-  [
-    "?"
-    ":"
-  ] @keyword.conditional)
+  ["?" ":"] @conditional)
 
-[
-  "do"
-  (throw_keyword)
-  (catch_keyword)
-] @keyword
+["do" (throw_keyword) (catch_keyword)] @keyword
 
 (statement_label) @label
 
@@ -214,25 +139,15 @@
 
 ; String literals
 (line_str_text) @string
-
 (str_escaped_char) @string
-
 (multi_line_str_text) @string
-
 (raw_str_part) @string
-
 (raw_str_end_part) @string
-
 (raw_str_interpolation_start) @punctuation.special
-
-[
-  "\""
-  "\"\"\""
-] @string
+["\"" "\"\"\""] @string
 
 ; Lambda literals
-(lambda_literal
-  "in" @keyword.operator)
+(lambda_literal ["in" @keyword.operator])
 
 ; Basic literals
 [
@@ -241,11 +156,8 @@
   (oct_literal)
   (bin_literal)
 ] @number
-
-(real_literal) @number.float
-
+(real_literal) @float
 (boolean_literal) @boolean
-
 "nil" @constant.builtin
 
 ; Regex literals
@@ -255,9 +167,8 @@
 (custom_operator) @operator
 
 [
-  "try"
-  "try?"
-  "try!"
+  "!"
+  "?"
   "+"
   "-"
   "*"
@@ -287,3 +198,8 @@
   "..."
   (bang)
 ] @operator
+
+(value_parameter_pack ["each" @keyword])
+(value_pack_expansion ["repeat" @keyword])
+(type_parameter_pack ["each" @keyword])
+(type_pack_expansion ["repeat" @keyword])

--- a/languages/swift/highlights.scm
+++ b/languages/swift/highlights.scm
@@ -20,8 +20,6 @@
 ] @keyword
 
 (function_declaration (simple_identifier) @method)
-
-(function_declaration (simple_identifier) @method)
 (init_declaration ["init" @constructor])
 (deinit_declaration ["deinit" @constructor])
 (throws) @keyword

--- a/languages/swift/highlights.scm
+++ b/languages/swift/highlights.scm
@@ -1,31 +1,14 @@
-[
-  "."
-  ";"
-  ":"
-  ","
-] @punctuation.delimiter
-
-; TODO: "\\(" ")" in interpolations should be @punctuation.special
-[
-  "\\("
-  "("
-  ")"
-  "["
-  "]"
-  "{"
-  "}"
-] @punctuation.bracket
+[ "." ";" ":" "," ] @punctuation.delimiter
+[ "\\(" "(" ")" "[" "]" "{" "}"] @punctuation.bracket ; TODO: "\\(" ")" in interpolations should be @punctuation.special
 
 ; Identifiers
 (attribute) @variable
-
 (type_identifier) @type
-
 (self_expression) @variable.builtin
+(user_type (type_identifier) @variable.builtin (#eq? @variable.builtin "Self"))
 
 ; Declarations
 "func" @keyword.function
-
 [
   (visibility_modifier)
   (member_modifier)
@@ -33,38 +16,21 @@
   (property_modifier)
   (parameter_modifier)
   (inheritance_modifier)
-  (mutation_modifier)
-] @type.qualifier
+] @keyword
 
-(function_declaration
-  (simple_identifier) @function.method)
-
-(function_declaration
-  "init" @constructor)
-
+(function_declaration (simple_identifier) @method)
+(init_declaration ["init" @constructor])
+(deinit_declaration ["deinit" @constructor])
 (throws) @keyword
-
+"async" @keyword
+"await" @keyword
 (where_keyword) @keyword
-
-(parameter
-  external_name: (simple_identifier) @variable.parameter)
-
-(parameter
-  name: (simple_identifier) @variable.parameter)
-
-(type_parameter
-  (type_identifier) @variable.parameter)
-
-(inheritance_constraint
-  (identifier
-    (simple_identifier) @variable.parameter))
-
-(equality_constraint
-  (identifier
-    (simple_identifier) @variable.parameter))
-
-(pattern
-  bound_identifier: (simple_identifier)) @variable
+(parameter external_name: (simple_identifier) @parameter)
+(parameter name: (simple_identifier) @parameter)
+(type_parameter (type_identifier) @parameter)
+(inheritance_constraint (identifier (simple_identifier) @parameter))
+(equality_constraint (identifier (simple_identifier) @parameter))
+(pattern bound_identifier: (simple_identifier)) @variable
 
 [
   "typealias"
@@ -79,13 +45,20 @@
   "override"
   "convenience"
   "required"
-  "some"
+  "mutating"
+  "associatedtype"
 ] @keyword
 
-[
-  "async"
-  "await"
-] @keyword.coroutine
+(opaque_type ["some" @keyword])
+(existential_type ["any" @keyword])
+
+(precedence_group_declaration
+ ["precedencegroup" @keyword]
+ (simple_identifier) @type)
+(precedence_group_attribute
+ (simple_identifier) @keyword
+ [(simple_identifier) @type
+  (boolean_literal) @boolean])
 
 [
   (getter_specifier)
@@ -93,197 +66,123 @@
   (modify_specifier)
 ] @keyword
 
-(class_body
-  (property_declaration
-    (pattern
-      (simple_identifier) @variable.member)))
+(class_body (property_declaration (pattern (simple_identifier) @property)))
+(protocol_property_declaration (pattern (simple_identifier) @property))
 
-(protocol_property_declaration
-  (pattern
-    (simple_identifier) @variable.member))
+(import_declaration ["import" @include])
 
-(navigation_expression
-  (navigation_suffix
-    (simple_identifier) @variable.member))
-
-(value_argument
-  name: (value_argument_label) @variable.member)
-
-(import_declaration
-  "import" @keyword.import)
-
-(enum_entry
-  "case" @keyword)
+(enum_entry ["case" @keyword])
 
 ; Function calls
-(call_expression
-  (simple_identifier) @function.call) ; foo()
-
-(call_expression
-  ; foo.bar.baz(): highlight the baz()
+(call_expression (simple_identifier) @function.call) ; foo()
+(call_expression ; foo.bar.baz(): highlight the baz()
   (navigation_expression
-    (navigation_suffix
-      (simple_identifier) @function.call)))
-
-(call_expression
-  (prefix_expression
-    (simple_identifier) @function.call)) ; .foo()
-
+    (navigation_suffix (simple_identifier) @function.call)))
 ((navigation_expression
-  (simple_identifier) @type) ; SomeType.method(): highlight SomeType as a type
-  (#lua-match? @type "^[A-Z]"))
+   (simple_identifier) @type) ; SomeType.method(): highlight SomeType as a type
+   (#match? @type "^[A-Z]"))
+(call_expression (simple_identifier) @keyword (#eq? @keyword "defer")) ; defer { ... }
+
+(try_operator) @operator
+(try_operator ["try" @keyword])
 
 (directive) @function.macro
-
 (diagnostic) @function.macro
 
 ; Statements
-(for_statement
-  "for" @keyword.repeat)
-
-(for_statement
-  "in" @keyword.repeat)
-
-(for_statement
-  (pattern) @variable)
-
+(for_statement ["for" @repeat])
+(for_statement ["in" @repeat])
+(for_statement (pattern) @variable)
 (else) @keyword
-
 (as_operator) @keyword
 
-[
-  "while"
-  "repeat"
-  "continue"
-  "break"
-] @keyword.repeat
+["while" "repeat" "continue" "break"] @repeat
 
-[
-  "let"
-  "var"
-] @keyword
+["let" "var"] @keyword
 
-(guard_statement
-  "guard" @keyword.conditional)
-
-(if_statement
-  "if" @keyword.conditional)
-
-(switch_statement
-  "switch" @keyword.conditional)
-
-(switch_entry
-  "case" @keyword)
-
-(switch_entry
-  "fallthrough" @keyword)
-
-(switch_entry
-  (default_keyword) @keyword)
-
+(guard_statement ["guard" @conditional])
+(if_statement ["if" @conditional])
+(switch_statement ["switch" @conditional])
+(switch_entry ["case" @keyword])
+(switch_entry ["fallthrough" @keyword])
+(switch_entry (default_keyword) @keyword)
 "return" @keyword.return
-
 (ternary_expression
-  [
-    "?"
-    ":"
-  ] @keyword.conditional)
+  ["?" ":"] @conditional)
 
-[
-  "do"
-  (throw_keyword)
-  (catch_keyword)
-] @keyword
+["do" (throw_keyword) (catch_keyword)] @keyword
 
 (statement_label) @label
 
 ; Comments
 [
-  (comment)
-  (multiline_comment)
+ (comment)
+ (multiline_comment)
 ] @comment @spell
-
-((comment) @comment.documentation
-  (#lua-match? @comment.documentation "^///[^/]"))
-
-((comment) @comment.documentation
-  (#lua-match? @comment.documentation "^///$"))
-
-((multiline_comment) @comment.documentation
-  (#lua-match? @comment.documentation "^/[*][*][^*].*[*]/$"))
 
 ; String literals
 (line_str_text) @string
-
 (str_escaped_char) @string
-
 (multi_line_str_text) @string
-
 (raw_str_part) @string
-
 (raw_str_end_part) @string
-
 (raw_str_interpolation_start) @punctuation.special
-
-[
-  "\""
-  "\"\"\""
-] @string
+["\"" "\"\"\""] @string
 
 ; Lambda literals
-(lambda_literal
-  "in" @keyword.operator)
+(lambda_literal ["in" @keyword.operator])
 
 ; Basic literals
 [
-  (integer_literal)
-  (hex_literal)
-  (oct_literal)
-  (bin_literal)
+ (integer_literal)
+ (hex_literal)
+ (oct_literal)
+ (bin_literal)
 ] @number
-
-(real_literal) @number.float
-
+(real_literal) @float
 (boolean_literal) @boolean
-
-"nil" @constant.builtin
+"nil" @variable.builtin
 
 ; Regex literals
-(regex_literal) @string.regexp
+(regex_literal) @string.regex
 
 ; Operators
 (custom_operator) @operator
-
 [
-  "try"
-  "try?"
-  "try!"
-  "+"
-  "-"
-  "*"
-  "/"
-  "%"
-  "="
-  "+="
-  "-="
-  "*="
-  "/="
-  "<"
-  ">"
-  "<="
-  ">="
-  "++"
-  "--"
-  "&"
-  "~"
-  "%="
-  "!="
-  "!=="
-  "=="
-  "==="
-  "??"
-  "->"
-  "..<"
-  "..."
-  (bang)
+ "!"
+ "?"
+ "+"
+ "-"
+ "*"
+ "/"
+ "%"
+ "="
+ "+="
+ "-="
+ "*="
+ "/="
+ "<"
+ ">"
+ "<="
+ ">="
+ "++"
+ "--"
+ "&"
+ "~"
+ "%="
+ "!="
+ "!=="
+ "=="
+ "==="
+ "??"
+
+ "->"
+
+ "..<"
+ "..."
 ] @operator
+
+(value_parameter_pack ["each" @keyword])
+(value_pack_expansion ["repeat" @keyword])
+(type_parameter_pack ["each" @keyword])
+(type_pack_expansion ["repeat" @keyword])

--- a/languages/swift/indents.scm
+++ b/languages/swift/indents.scm
@@ -1,10 +1,11 @@
-; format-ignore
 [
   ; ... refers to the section that will get affected by this indent.begin capture
   (protocol_body)               ; protocol Foo { ... }
   (class_body)                  ; class Foo { ... }
   (enum_class_body)             ; enum Foo { ... }
   (function_declaration)        ; func Foo (...) {...}
+  (init_declaration)            ; init(...) {...}
+  (deinit_declaration)          ; deinit {...}
   (computed_property)           ; { ... }
   (subscript_declaration)       ; subscript Foo(...) { ... }
 
@@ -31,12 +32,15 @@
   (tuple_expression)            ; ( foo + bar )
   (array_literal)               ; [ foo, bar ]
   (dictionary_literal)          ; [ foo: bar, x: y ]
-  (lambda_literal)
+  (lambda_literal) 
+  (willset_didset_block)
+  (willset_clause)
+  (didset_clause)
 ] @indent.begin
 
 ; @something(...)
-(modifiers
-  (attribute) @indent.begin)
+((modifiers
+  (attribute) @indent.begin))
 
 (function_declaration
   (modifiers
@@ -47,13 +51,16 @@
   _ @indent.branch
   (#not-has-type? @indent.branch type_parameters parameter))
 
+
 (ERROR
   [
-    "<"
-    "{"
-    "("
+    "<" 
+    "{" 
+    "(" 
     "["
-  ]) @indent.begin
+  ]
+) @indent.begin
+
 
 ; if-elseif
 (if_statement
@@ -62,33 +69,22 @@
 ; case Foo:
 ; default Foo:
 ; @attribute default Foo:
-(switch_entry
-  .
-  _ @indent.branch)
+(switch_entry . _ @indent.branch)
 
-(function_declaration
-  ")" @indent.branch)
+(function_declaration ")" @indent.branch)
 
-(type_parameters
-  ">" @indent.branch @indent.end .)
-
-(tuple_expression
-  ")" @indent.branch @indent.end)
-
-(value_arguments
-  ")" @indent.branch @indent.end)
-
-(tuple_type
-  ")" @indent.branch @indent.end)
-
+(type_parameters ">" @indent.branch @indent.end .)
+(tuple_expression ")" @indent.branch @indent.end)
+(value_arguments ")" @indent.branch @indent.end)
+(tuple_type ")" @indent.branch @indent.end)
 (modifiers
-  (attribute
-    ")" @indent.branch @indent.end))
+  (attribute ")" @indent.branch @indent.end))
 
 [
   "}"
   "]"
 ] @indent.branch @indent.end
+
 
 [
   ; (ERROR)

--- a/languages/swift/injections.scm
+++ b/languages/swift/injections.scm
@@ -1,0 +1,4 @@
+; Parse regex syntax within regex literals
+
+((regex_literal) @injection.content
+ (#set! injection.language "regex"))

--- a/languages/swift/locals.scm
+++ b/languages/swift/locals.scm
@@ -1,21 +1,18 @@
-(import_declaration
-  (identifier) @local.definition.import)
-
-(function_declaration
-  name: (simple_identifier) @local.definition.function)
+(import_declaration (identifier) @definition.import)
+(function_declaration name: (simple_identifier) @definition.function)
 
 ; Scopes
 [
-  (statements)
-  (for_statement)
-  (while_statement)
-  (repeat_while_statement)
-  (do_statement)
-  (if_statement)
-  (guard_statement)
-  (switch_statement)
-  (property_declaration)
-  (function_declaration)
-  (class_declaration)
-  (protocol_declaration)
+ (statements)
+ (for_statement)
+ (while_statement)
+ (repeat_while_statement)
+ (do_statement)
+ (if_statement)
+ (guard_statement)
+ (switch_statement)
+ (property_declaration)
+ (function_declaration)
+ (class_declaration)
+ (protocol_declaration)
 ] @local.scope

--- a/languages/swift/tags.scm
+++ b/languages/swift/tags.scm
@@ -1,0 +1,51 @@
+(class_declaration
+  name: (type_identifier) @name) @definition.class
+
+(protocol_declaration
+  name: (type_identifier) @name) @definition.interface
+
+(class_declaration
+    (class_body
+        [
+            (function_declaration
+                name: (simple_identifier) @name
+            )
+            (subscript_declaration
+                (parameter (simple_identifier) @name)
+            )
+            (init_declaration "init" @name)
+            (deinit_declaration "deinit" @name)
+        ]
+    )
+) @definition.method
+
+(protocol_declaration
+    (protocol_body
+        [
+            (protocol_function_declaration
+                name: (simple_identifier) @name
+            )
+            (subscript_declaration
+                (parameter (simple_identifier) @name)
+            )
+            (init_declaration "init" @name)
+        ]
+    )
+) @definition.method
+
+(class_declaration
+    (class_body
+        [
+            (property_declaration
+                (pattern (simple_identifier) @name)
+            )
+        ]
+    )
+) @definition.property
+
+(property_declaration
+    (pattern (simple_identifier) @name)
+) @definition.property
+
+(function_declaration
+    name: (simple_identifier) @name) @definition.function

--- a/languages/swift/textobjects.scm
+++ b/languages/swift/textobjects.scm
@@ -1,0 +1,19 @@
+
+
+; MARK: Structure
+
+(function_declaration
+  body: (_) @function.inside) @function.around
+
+; TODO: Classes/structs/enums
+
+
+; MARK: Tests
+
+; Only matches prefix test. Other conventions
+; might be nice to add!
+(function_declaration
+	name: (simple_identifier) @_name
+	(#match? @_name "^test")
+)
+

--- a/src/swift.rs
+++ b/src/swift.rs
@@ -1,0 +1,23 @@
+use zed_extension_api::{self as zed, Result};
+
+struct SwiftExtension {}
+
+impl zed::Extension for SwiftExtension {
+    fn new() -> Self {
+        Self {}
+    }
+
+    fn language_server_command(
+        &mut self,
+        _server_id: &zed::LanguageServerId,
+        _worktree: &zed::Worktree,
+    ) -> Result<zed::Command> {
+        Ok(zed::Command {
+            command: "/usr/bin/xcrun".into(),
+            args: vec!["sourcekit-lsp".into()],
+            env: Default::default(),
+        })
+    }
+}
+
+zed::register_extension!(SwiftExtension);


### PR DESCRIPTION
Adds improved syntax highlighting of:
- `import` statements
- `#if` preprocessor statements
- as well as `/** */` comments
 
Which all otherwise appear in full opacity white color (without syntax highlighting) and makes it difficult to read & write Swift code.

**Screenshots**
<img width="634" alt="328725936-f970bf3f-6401-46ce-89e5-bdadad313dfa" src="https://github.com/ejjonny/swift/assets/18516968/96cc9d1f-c20e-45d7-ad02-1ab7739defe1">

<img width="1079" alt="328726244-97cedc50-0056-4cd6-9acd-c50fe7c530b2" src="https://github.com/ejjonny/swift/assets/18516968/da37ea2e-d7e1-45d8-8b0e-a11867c5a75f">